### PR TITLE
s/ps -aux/ps aux/g, fixes bogus '-' error

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -218,10 +218,10 @@ server_is_running() {
   #   0 if server is running
   #   1 if server is not running
   
-  if [ -z "$(ps -aux | grep -v grep | grep "$java.*nuid=$name-nuid")" ]; then
+  if [ -z "$(ps aux | grep -v grep | grep "$java.*nuid=$name-nuid")" ]; then
     return 1
   else
-    if [ -z "$(ps -aux | grep -v grep | grep "$java.*nuid=$name-nuid" | grep -v "bash")" ]; then
+    if [ -z "$(ps aux | grep -v grep | grep "$java.*nuid=$name-nuid" | grep -v "bash")" ]; then
       return 1
     else
       return 0
@@ -459,7 +459,7 @@ server_stop() {
   server_command "stop"
   
   # Sleep until server is stopped
-  while kill -0 "$(ps -aux | grep -v grep | grep "$java.*nuid=$name-nuid" | grep -v "bash" | awk '{print $2}')" &> /dev/null; do
+  while kill -0 "$(ps aux | grep -v grep | grep "$java.*nuid=$name-nuid" | grep -v "bash" | awk '{print $2}')" &> /dev/null; do
     sleep 1
   done
   


### PR DESCRIPTION
re: https://gitorious.org/procps/procps/source/fc7cb8dd4cd91da3d2df35b8863247674e4fd1ed:Documentation/FAQ

> Why does "ps -aux" complain about a bogus '-'?
> According to the POSIX and UNIX standards, the above command asks to
> display all processes with a TTY (generally the commands users are
> running) plus all processes owned by a user named "x". If that user
> doesn't exist, then ps will assume you really meant "ps aux". The
> warning is given to gently break you of a habit that will cause you
> trouble if a user named "x" were created.

:smile_cat: 
