### PR TITLE
Fix failure to start via /etc/rc*.d

### DIFF
--- a/minecraft
+++ b/minecraft
@@ -18,6 +18,13 @@
 # Name of script
 name=$(basename $0)
 
+# Remove startup/shutdown prefix used by /etc/rc*.d, if present.
+# Prefix is Snn for startup or Knn for shutdown, where n is a digit.
+prefix_regex="^(S|K)\d{2}"
+if test `echo ${name} | grep -Pc ${prefix_regex}` -ne 0; then
+  name=`echo ${name} | grep -Po "(?<=${prefix_regex}).+"`
+fi
+
 # Read configuration variable file if it is present
 if [ -r /etc/default/$name ]; then
   source /etc/default/$name


### PR DESCRIPTION
I discovered that the script would not start my configured Minecraft instances when run at startup, but it worked just fine when run by hand as 'service minecraft start'. It turns out the init system in the Ubuntu 14.04 lxc template uses /etc/rc*.d, which call the script as S20minecraft (startup) or K20minecraft (shutdown), but the script was expecting to be called as just minecraft.

This patch removes the leading Snn or Knn, if present.
